### PR TITLE
[#118552679] Made TSA template compatible with bosh-init

### DIFF
--- a/jobs/tsa/spec
+++ b/jobs/tsa/spec
@@ -78,3 +78,8 @@ properties:
     description: |
       Environment name to specify for errors emitted to Yeller.
     default: ""
+
+  tsa_atc_address:
+    description: |
+      atc server connection address
+    default: "127.0.0.1:8080"

--- a/jobs/tsa/templates/tsa_ctl.erb
+++ b/jobs/tsa/templates/tsa_ctl.erb
@@ -10,7 +10,12 @@ set -e
     Shellwords.shellescape(x)
   end
 
-  atc = link("atc")
+  if !spec.address or spec.address == ""
+    peer_ip = "127.0.0.1"
+  else
+    peer_ip = spec.address
+  end
+
 %>
 
 RUN_DIR=/var/vcap/sys/run/tsa
@@ -51,10 +56,15 @@ EOF
 
     # TODO: TSA should support multiple ATCs
     exec chpst -u vcap:vcap /var/vcap/packages/tsa/bin/tsa \
+      <% if if_link("atc") %>
+      <% atc = link("atc") %>
       <% atc.instances.each do |instance| %> \
       --atc-url <%= "http://#{instance.address}:#{atc.p("bind_port")}" %> \
       <% end %> \
-      --peer-ip <%= spec.address %> \
+      <% else %> \
+      --atc-url http://<%= p("tsa_atc_address") %> \
+      <% end %> \
+      --peer-ip <%= peer_ip %> \
       --bind-port <%= p("bind_port") %> \
       <% if p("host_key") != "" %> \
       --host-key /var/vcap/jobs/tsa/config/host_key \


### PR DESCRIPTION
# What

Use of the link() method and `spec.address` is now conditional to enable compatibility with bosh-init. Tested using bosh-init v0.0.87.

This is based on Concourse v1.1.0. This will be merged in branch `gds_1.1.0_bosh_init_fix` of our fork so we can use it in our build. We will then raise a similar PR against upstream master.
# How to review
- Build deployer concourse using paas-cf branch `keep/118552679_concourse_update` and [bosh-init image](https://hub.docker.com/r/governmentpaas/bosh-init/tags/) `keep_118552679_concourse_update`
- You can use the test release: 
  https://github.com/alphagov/paas-concourse/releases/download/1.1.0-gds/concourse-1.1.0.dev.3.tgz
  (sha1 843abb16b4d9b7709a881931d3fd40f0cad1ff9e)
- It should build successfully and the pipeline should run without any issue.
# Who can review

Anyone but @HenryTK or myself.
