### PR TITLE
[#127256345] Add option to configure baggageclaim volumes image size

### DIFF
--- a/jobs/baggageclaim/spec
+++ b/jobs/baggageclaim/spec
@@ -37,3 +37,10 @@ properties:
     description: |
       Environment name to specify for errors emitted to Yeller.
     default: ""
+
+  volumes_image_size_mb:
+    description: |
+      The size in megabytes of the volumes image to allocate. This is allocated
+      under /var/vcap/data, so should leave enough space for everything else.
+      Defaults to the filesystem size minus 10Gig.
+    default: -1

--- a/jobs/baggageclaim/templates/baggageclaim_ctl.erb
+++ b/jobs/baggageclaim/templates/baggageclaim_ctl.erb
@@ -30,7 +30,7 @@ case $1 in
     chown -R vcap:vcap $LOG_DIR
 
     IMAGE_PATH=/var/vcap/data/baggageclaim/volumes.img
-    IMAGE_SIZE=$(df -m /var/vcap/data | tail -n1 | awk '{print $2}')
+    IMAGE_SIZE=$(($(df -m /var/vcap/data | tail -n1 | awk '{print $2}') - 10 * 1024))
     mkdir -p $(dirname ${IMAGE_PATH})
 
     VOLUMES_DIR=/var/vcap/data/baggageclaim/volumes

--- a/jobs/baggageclaim/templates/baggageclaim_ctl.erb
+++ b/jobs/baggageclaim/templates/baggageclaim_ctl.erb
@@ -30,7 +30,11 @@ case $1 in
     chown -R vcap:vcap $LOG_DIR
 
     IMAGE_PATH=/var/vcap/data/baggageclaim/volumes.img
+  <% if p('volumes_image_size_mb') > 0 %>
+    IMAGE_SIZE=<%= p('volumes_image_size_mb') %>
+  <% else %>
     IMAGE_SIZE=$(($(df -m /var/vcap/data | tail -n1 | awk '{print $2}') - 10 * 1024))
+  <% end %>
     mkdir -p $(dirname ${IMAGE_PATH})
 
     VOLUMES_DIR=/var/vcap/data/baggageclaim/volumes


### PR DESCRIPTION
# What

Add option to configure the baggageclaim volumes image size. Also update the default size to be more sensible. See individual commit messages for more detail.
# How to review

Review as part of paas-cf PR (https://github.com/alphagov/paas-cf/pull/394).
# After merge

Once this is merged, I intend to:
- create a tag `1.5.1.gds1` for the merge commit.
- create a github release for this tag
- create a dev build of this boshrelease as follows:

``` sh
echo "1.5.1.gds1" > src/version/VERSION
bosh create release --name concourse --version "1.5.1.gds1" --with-tarball
```
- Upload the resulting tarball to the github release.
- Update the paas-cf PR to point at this release.
# Who can review

Anyone but @mtekel or myself.
